### PR TITLE
chore(api): tighten lint rules and dev scripts

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -16,11 +16,15 @@ export default [
   ...tseslint.configs.recommended,
 
   {
-    files: ["**/*.{ts,tsx,js,cjs}"],
+    files: ["src/**/*.{ts,tsx,js,cjs}"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "module",
       parser: tseslint.parser,
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
       globals: {
         console: "readonly",
         module: "readonly",
@@ -44,6 +48,12 @@ export default [
           varsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
         },
+      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", disallowTypeAnnotations: false }
       ],
     },
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,13 +5,16 @@
   "type": "commonjs",
   "scripts": {
     "dev": "tsx src/app.ts",
+    "start:dev": "tsx src/app.ts",
     "build": "tsc -p tsconfig.json && npm run openapi:gen",
     "start:prod": "node dist/app.js",
     "openapi:gen": "tsx src/openapi.ts",
+    "coverage": "npm run test -- --coverage",
     "migrate": "powershell -ExecutionPolicy Bypass -File ./migrate.ps1",
     "db:check": "powershell -NoProfile -File ./db-check.ps1",
     "lint": "eslint . --ext .ts,.tsx,.js,.cjs",
     "lint:fix": "eslint . --fix",
+    "depcheck": "npx depcheck --ignores=oracledb",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "ROLLUP_DISABLE_NATIVE=1 vitest run",
     "test:watch": "ROLLUP_DISABLE_NATIVE=1 vitest"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, NextFunction } from "express";
+import express, { type Request, type Response, type NextFunction } from "express";
 import "dotenv/config";
 import cors from "cors";
 import helmet from "helmet";


### PR DESCRIPTION
## Summary
- enforce async and type-import safety with new ESLint rules
- add development scripts for coverage and dep checking
- fix express type imports to satisfy new lint rule

## Testing
- `npm run -w apps/api lint`
- `npm run -w apps/api typecheck`
- `npm run -w apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c819bb18832290d3b7fd87202d0f